### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ xattr -cr /Applications/TikMatrix.app
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tikmatrix/tikmatrix-desktop&type=Date)](https://star-history.com/#tikmatrix/tikmatrix-desktop&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tikmatrix/tikmatrix-desktop&type=Date)](https://star-history.dera.page/#tikmatrix/tikmatrix-desktop&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer
renders due to GitHub stargazer API restrictions, so the chart needs to be
fixed. This change points it to a working replacement, with no other
behavior changes.